### PR TITLE
Refactors bulletin data model and UI (#28)

### DIFF
--- a/.cursor/rules/zvavi-kotlin-rule.mdc
+++ b/.cursor/rules/zvavi-kotlin-rule.mdc
@@ -135,3 +135,10 @@ Never delete comments until I ask.
 
 - Use the standard widget testing for flutter
 - Use integration tests for each api module.   
+
+### Patterns
+- alwayes say where we can use GOF patterns ar GRASP patterns and propose to implement them and explain why
+- check for waye to make lower coulping and higher cohesion and explain why
+- alwayes check for adherence of Solid principles - propose to implemnt them where possible and explain why
+
+

--- a/common/core/designsystem/src/commonMain/composeResources/values/strings.xml
+++ b/common/core/designsystem/src/commonMain/composeResources/values/strings.xml
@@ -16,4 +16,20 @@
     <string name="explore">Explore</string>
     <string name="bulletin">Bulletin</string>
     <string name="settings">Settings</string>
+    <string name="recent_avalanches">Recent avalanches</string>
+    <string name="snowpack">Snowpack</string>
+    <string name="weather">Weather</string>
+    <string name="collapse">collapse</string>
+    <string name="expand">expand</string>
+    <string name="size_label">Size: </string>
+    <string name="aspect_by_elevation">Aspect by Elevation</string>
+    <string name="detailed_description">Detailed Description</string>
+    <string name="zvavi">Zvavi</string>
+    <string name="avalanche_safety">Avalanche Safety</string>
+    <string name="close_button">close button</string>
+    <string name="expanded_arrow">expanded arrow</string>
+    <string name="all_day">All day</string>
+    <string name="trend">Trend</string>
+    <string name="time_of_day">Time of day</string>
+    <string name="avalanche_size_info">Avalanche Size Info</string>
 </resources>

--- a/common/core/designsystem/src/commonMain/kotlin/ge/avalanche/zvavi/designsystem/Platform.kt
+++ b/common/core/designsystem/src/commonMain/kotlin/ge/avalanche/zvavi/designsystem/Platform.kt
@@ -8,6 +8,7 @@ expect fun getPlatform(): String
 @Composable
 expect fun getPlatformScreenDimensions(): PlatformScreenDimensions
 
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 expect class PlatformScreenDimensions {
     val width: Dp
     val height: Dp

--- a/common/core/designsystem/src/commonMain/kotlin/ge/avalanche/zvavi/designsystem/components/boards/ZvaviDashboard.kt
+++ b/common/core/designsystem/src/commonMain/kotlin/ge/avalanche/zvavi/designsystem/components/boards/ZvaviDashboard.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import ge.avalanche.zvavi.designsystem.dimens.Stroke
+import ge.avalanche.zvavi.designsystem.dimens.ZvaviStroke
 import ge.avalanche.zvavi.designsystem.dimens.ZvaviRadius
 import ge.avalanche.zvavi.designsystem.dimens.ZvaviSize
 import ge.avalanche.zvavi.designsystem.dimens.ZvaviSpacing
@@ -51,7 +51,7 @@ fun ZvaviDashboard(
             .fillMaxSize()
             .clip(RoundedCornerShape(ZvaviRadius.radius550))
             .border(
-                width = Stroke.stroke200,
+                width = ZvaviStroke.stroke200,
                 shape = RoundedCornerShape(ZvaviRadius.radius550),
                 color = ZvaviTheme.colors.borderNeutralTertiary
             )

--- a/common/core/designsystem/src/commonMain/kotlin/ge/avalanche/zvavi/designsystem/components/expandableSection/ZvaviExpandableSection.kt
+++ b/common/core/designsystem/src/commonMain/kotlin/ge/avalanche/zvavi/designsystem/components/expandableSection/ZvaviExpandableSection.kt
@@ -1,0 +1,113 @@
+package ge.avalanche.zvavi.designsystem.components.expandableSection
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import ge.avalanche.zvavi.designsystem.dimens.ZvaviAngle
+import ge.avalanche.zvavi.designsystem.dimens.ZvaviSpacing
+import ge.avalanche.zvavi.designsystem.icons.ZvaviIcons
+import ge.avalanche.zvavi.designsystem.strings.ZvaviStrings
+import ge.avalanche.zvavi.designsystem.theme.ZvaviTheme
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun ZvaviExpandableSection(
+    sectionTitle: @Composable () -> Unit,
+    isExpanded: Boolean = false,
+    onExpandedChange: ((Boolean) -> Unit)? = null,
+    isNavigationMode: Boolean = false,
+    onNavigateClick: (() -> Unit)? = null,
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit = {}
+) {
+    val rotationAngle by animateFloatAsState(
+        targetValue = if (isExpanded) ZvaviAngle.angle0 else ZvaviAngle.angleMinus90,
+        label = "expandArrowRotation"
+    )
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(
+            space = ZvaviSpacing.spacing100,
+            alignment = Alignment.CenterVertically
+        ),
+
+
+                modifier = modifier
+            .fillMaxWidth()
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null  // This removes the ripple
+            ) {
+                when {
+                    isNavigationMode && onNavigateClick != null -> onNavigateClick()
+                    !isNavigationMode && onExpandedChange != null -> onExpandedChange(!isExpanded)
+                }
+            }
+            .wrapContentHeight()
+            .padding(vertical = ZvaviSpacing.spacing150)
+    ) {
+        ExpandableToggleRow(
+            isExpanded = isExpanded,
+            sectionTitle = sectionTitle,
+            rotationAngle = rotationAngle,
+
+            )
+
+        if (!isNavigationMode) {
+            AnimatedVisibility(
+                visible = isExpanded,
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut()
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            horizontal = ZvaviSpacing.spacing200,
+                            vertical = ZvaviSpacing.spacing200
+                        )
+                ) {
+                    content()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ExpandableToggleRow(
+    isExpanded: Boolean,
+    rotationAngle: Float,
+    sectionTitle: @Composable() () -> Unit = {},
+) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        sectionTitle()
+        Icon(
+            imageVector = ZvaviIcons.DropDownArrow,
+            contentDescription = if (isExpanded) stringResource(ZvaviStrings.collapse) else stringResource(
+                ZvaviStrings.expand
+            ),
+            tint = ZvaviTheme.colors.contentNeutralTertiary,
+            modifier = Modifier.graphicsLayer(rotationZ = rotationAngle)
+        )
+    }
+}

--- a/common/core/designsystem/src/commonMain/kotlin/ge/avalanche/zvavi/designsystem/components/header/ZvaviHeader.kt
+++ b/common/core/designsystem/src/commonMain/kotlin/ge/avalanche/zvavi/designsystem/components/header/ZvaviHeader.kt
@@ -1,0 +1,19 @@
+package ge.avalanche.zvavi.designsystem.components.header
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import ge.avalanche.zvavi.designsystem.theme.ZvaviTheme
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun ZvaviHeader(text: StringResource, modifier: Modifier = Modifier) {
+    Text(
+        text = stringResource(text),
+        style = ZvaviTheme.typography.display400Accent.copy(color = ZvaviTheme.colors.contentNeutralPrimary),
+        modifier = modifier.fillMaxWidth().wrapContentHeight()
+    )
+}

--- a/common/core/designsystem/src/commonMain/kotlin/ge/avalanche/zvavi/designsystem/dimens/Dimens.kt
+++ b/common/core/designsystem/src/commonMain/kotlin/ge/avalanche/zvavi/designsystem/dimens/Dimens.kt
@@ -67,7 +67,7 @@ data object ZvaviSpacing {
 }
 
 @Immutable
-data object Stroke {
+data object ZvaviStroke {
     val stroke0 = 0.dp
     val stroke100 = 1.dp
     val stroke200 = 2.dp

--- a/common/core/designsystem/src/commonMain/kotlin/ge/avalanche/zvavi/designsystem/strings/ZvaviStrings.kt
+++ b/common/core/designsystem/src/commonMain/kotlin/ge/avalanche/zvavi/designsystem/strings/ZvaviStrings.kt
@@ -2,9 +2,18 @@ package ge.avalanche.zvavi.designsystem.strings
 
 import org.jetbrains.compose.resources.StringResource
 import zvaviapp.common.core.designsystem.generated.resources.Res
+import zvaviapp.common.core.designsystem.generated.resources.all_day
 import zvaviapp.common.core.designsystem.generated.resources.alpine
+import zvaviapp.common.core.designsystem.generated.resources.aspect_by_elevation
+import zvaviapp.common.core.designsystem.generated.resources.avalanche_safety
+import zvaviapp.common.core.designsystem.generated.resources.avalanche_size_info
 import zvaviapp.common.core.designsystem.generated.resources.bulletin
+import zvaviapp.common.core.designsystem.generated.resources.close_button
+import zvaviapp.common.core.designsystem.generated.resources.collapse
 import zvaviapp.common.core.designsystem.generated.resources.danger_level
+import zvaviapp.common.core.designsystem.generated.resources.detailed_description
+import zvaviapp.common.core.designsystem.generated.resources.expand
+import zvaviapp.common.core.designsystem.generated.resources.expanded_arrow
 import zvaviapp.common.core.designsystem.generated.resources.explore
 import zvaviapp.common.core.designsystem.generated.resources.gudauri
 import zvaviapp.common.core.designsystem.generated.resources.height_0
@@ -15,10 +24,17 @@ import zvaviapp.common.core.designsystem.generated.resources.info
 import zvaviapp.common.core.designsystem.generated.resources.overall_risk_level
 import zvaviapp.common.core.designsystem.generated.resources.overview
 import zvaviapp.common.core.designsystem.generated.resources.problems
+import zvaviapp.common.core.designsystem.generated.resources.recent_avalanches
 import zvaviapp.common.core.designsystem.generated.resources.risk_by_height
 import zvaviapp.common.core.designsystem.generated.resources.settings
+import zvaviapp.common.core.designsystem.generated.resources.size_label
+import zvaviapp.common.core.designsystem.generated.resources.snowpack
 import zvaviapp.common.core.designsystem.generated.resources.sub_alpine
+import zvaviapp.common.core.designsystem.generated.resources.time_of_day
 import zvaviapp.common.core.designsystem.generated.resources.travel_advice
+import zvaviapp.common.core.designsystem.generated.resources.trend
+import zvaviapp.common.core.designsystem.generated.resources.weather
+import zvaviapp.common.core.designsystem.generated.resources.zvavi
 
 object ZvaviStrings {
     val overallRiskLevel: StringResource get() = Res.string.overall_risk_level
@@ -38,4 +54,20 @@ object ZvaviStrings {
     val explore: StringResource get() = Res.string.explore
     val settings: StringResource get() = Res.string.settings
     val bulletin: StringResource get() = Res.string.bulletin
+    val recentAvalanches: StringResource get() = Res.string.recent_avalanches
+    val snowpack: StringResource get() = Res.string.snowpack
+    val weather: StringResource get() = Res.string.weather
+    val collapse: StringResource get() = Res.string.collapse
+    val expand: StringResource get() = Res.string.expand
+    val sizeLabel: StringResource get() = Res.string.size_label
+    val aspectByElevation: StringResource get() = Res.string.aspect_by_elevation
+    val detailedDescription: StringResource get() = Res.string.detailed_description
+    val zvavi: StringResource get() = Res.string.zvavi
+    val avalancheSafety: StringResource get() = Res.string.avalanche_safety
+    val closeButton: StringResource get() = Res.string.close_button
+    val expandedArrow: StringResource get() = Res.string.expanded_arrow
+    val allDay: StringResource get() = Res.string.all_day
+    val trend: StringResource get() = Res.string.trend
+    val timeOfDay: StringResource get() = Res.string.time_of_day
+    val avalancheSizeInfo: StringResource get() = Res.string.avalanche_size_info
 }

--- a/common/core/foundation/src/commonMain/kotlin/ge/avalanche/zvavi/foundation/base/BaseViewModel.kt
+++ b/common/core/foundation/src/commonMain/kotlin/ge/avalanche/zvavi/foundation/base/BaseViewModel.kt
@@ -6,9 +6,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.datetime.Clock
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 
 abstract class BaseViewModel<State : Any, Action, Event>(initialState: State) : ViewModel() {
     private val _viewStates = MutableStateFlow(initialState)

--- a/common/core/foundation/src/commonMain/kotlin/ge/avalanche/zvavi/foundation/navigation/Destinations.kt
+++ b/common/core/foundation/src/commonMain/kotlin/ge/avalanche/zvavi/foundation/navigation/Destinations.kt
@@ -31,3 +31,10 @@ object SettingScreenDestination : ZvaviNavDestinations, ZvaviNavAnimations by Fa
     override val route: String = ZvaviRoutes.SETTING_SCREEN
     override val arguments: List<NamedNavArgument> = emptyList()
 }
+
+object ExploreAvalancheSizeInfoScreenDestination : ZvaviNavDestinations,
+    ZvaviNavAnimations by FadeAnimations {
+    override val route = ZvaviRoutes.EXPLORER_AVALANCHE_SIZE_INFO_SCREEN
+    override val arguments: List<NamedNavArgument>
+        get() = emptyList()
+}

--- a/common/core/foundation/src/commonMain/kotlin/ge/avalanche/zvavi/foundation/navigation/ZvaviRoutes.kt
+++ b/common/core/foundation/src/commonMain/kotlin/ge/avalanche/zvavi/foundation/navigation/ZvaviRoutes.kt
@@ -6,5 +6,6 @@ object ZvaviRoutes {
     const val BULLETIN_SCREEN = "bulletin_screen"
     const val BULLETIN_PROBLEM_INFO_SCREEN = "bulletin_problem_screen"
     const val EXPLORER_SCREEN = "explorer_screen"
+    const val EXPLORER_AVALANCHE_SIZE_INFO_SCREEN = "explorer_avalanche_size_info_screen"
     const val SETTING_SCREEN = "setting_screen"
 } 

--- a/common/feature/bulletin/api/src/commonMain/kotlin/ge/avalanche/zvavi/bulletin/api/models/Bulletin.kt
+++ b/common/feature/bulletin/api/src/commonMain/kotlin/ge/avalanche/zvavi/bulletin/api/models/Bulletin.kt
@@ -15,7 +15,7 @@ data class Bulletin(
     val additionalHazards: String,
     val hazardLevels: HazardLevels,
     val avalancheProblems: List<AvalancheProblem>,
-    val recentAvalanches: List<RecentAvalanches>
+    val recentAvalanches: List<RecentAvalanche>
 ) {
     companion object {
         val EMPTY = Bulletin(
@@ -36,7 +36,7 @@ data class Bulletin(
     }
 }
 
-data class RecentAvalanches(
+data class RecentAvalanche(
     val aspects: Aspects,
     val date: String,
     val description: String,

--- a/common/feature/bulletin/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/bulletin/presentation/BulletinViewModel.kt
+++ b/common/feature/bulletin/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/bulletin/presentation/BulletinViewModel.kt
@@ -51,6 +51,9 @@ internal class BulletinViewModel(
             BulletinEvent.ProblemInfoClicked -> handleNavigateToBulletinProblemInfoScreen()
             BulletinEvent.ReturnFromBulletinProblemInfoScreen -> handleReturnFromBulletinProblemScreen()
             BulletinEvent.Retry -> {}
+            BulletinEvent.AvalancheSizeInfoClicked -> {
+                handleAvalancheSizeInfoClick()
+            }
         }
     }
 
@@ -172,6 +175,14 @@ internal class BulletinViewModel(
 
     private fun handleOverviewClick() {
         // Implementation for overview click
+    }
+
+    private fun handleAvalancheSizeInfoClick() {
+        viewAction = BulletinAction.OpenAvalancheSizeInfoScreen
+    }
+
+    private fun handleAvalancheProblemsClick() {
+        viewAction = BulletinAction.OpenProblemInfoScreen
     }
 
     fun getCurrentDateTime() =

--- a/common/feature/bulletin/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/bulletin/presentation/models/BulletinAction.kt
+++ b/common/feature/bulletin/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/bulletin/presentation/models/BulletinAction.kt
@@ -7,4 +7,5 @@ sealed class BulletinAction {
     data object OpenRecentAvalanches : BulletinAction()
     data object OpenSnowpack : BulletinAction()
     data object OpenWeather : BulletinAction()
+    data object OpenAvalancheSizeInfoScreen : BulletinAction()
 }

--- a/common/feature/bulletin/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/bulletin/presentation/models/BulletinEvent.kt
+++ b/common/feature/bulletin/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/bulletin/presentation/models/BulletinEvent.kt
@@ -16,4 +16,5 @@ sealed class BulletinEvent {
     object ProblemInfoClicked : BulletinEvent()
     object ReturnFromBulletinProblemInfoScreen : BulletinEvent()
     object Retry : BulletinEvent()
+    object AvalancheSizeInfoClicked : BulletinEvent()
 }

--- a/common/feature/bulletin/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/bulletin/presentation/models/BulletinViewState.kt
+++ b/common/feature/bulletin/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/bulletin/presentation/models/BulletinViewState.kt
@@ -2,7 +2,7 @@ package ge.avalanche.zvavi.bulletin.presentation.models
 
 import ge.avalanche.zvavi.bulletin.api.models.AvalancheProblem
 import ge.avalanche.zvavi.bulletin.api.models.AvalancheRiskLevel
-import ge.avalanche.zvavi.bulletin.api.models.RecentAvalanches
+import ge.avalanche.zvavi.bulletin.api.models.RecentAvalanche
 
 data class BulletinViewState(
     val riskLevelOverall: AvalancheRiskLevel = AvalancheRiskLevel.NO_INFO,
@@ -13,7 +13,7 @@ data class BulletinViewState(
     val riskLevelAlpine: AvalancheRiskLevel = AvalancheRiskLevel.NO_INFO,
     val riskLevelSubAlpine: AvalancheRiskLevel = AvalancheRiskLevel.NO_INFO,
     val avalancheProblems: List<AvalancheProblem> = emptyList(),
-    val recentAvalanches: List<RecentAvalanches > = emptyList(),
+    val recentAvalanches: List<RecentAvalanche > = emptyList(),
     val snowpack: String = "",
     val weather: String = "",
     val loading: Boolean = true,

--- a/common/feature/bulletin/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/bulletin/presentation/navigation/BulletinGraph.kt
+++ b/common/feature/bulletin/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/bulletin/presentation/navigation/BulletinGraph.kt
@@ -6,19 +6,19 @@ import ge.avalanche.zvavi.bulletin.presentation.screen.BulletinProblemInfoScreen
 import ge.avalanche.zvavi.bulletin.presentation.screen.BulletinScreen
 import ge.avalanche.zvavi.foundation.navigation.BulletinProblemInfoScreenDestination
 import ge.avalanche.zvavi.foundation.navigation.BulletinScreenDestination
+import ge.avalanche.zvavi.foundation.navigation.ExploreAvalancheSizeInfoScreenDestination
+import ge.avalanche.zvavi.foundation.navigation.ExplorerScreenDestination
 import ge.avalanche.zvavi.foundation.navigation.ZvaviNavDestinations
 import ge.avalanche.zvavi.foundation.navigation.zvaviComposable
 
-@Suppress("UNUSED_PARAMETER")
 fun NavGraphBuilder.bulletinGraph(
     navigateToDestination: (ZvaviNavDestinations, String?, (NavOptionsBuilder.() -> Unit)?) -> Unit,
 ) {
     zvaviComposable(destinations = BulletinScreenDestination) {
-        BulletinScreen(onNavigate = {
-            navigateToDestination(BulletinProblemInfoScreenDestination, route) {}
+        BulletinScreen(onNavigate = { destination ->
+            navigateToDestination(destination, route) {}
         })
     }
-
     zvaviComposable(destinations = BulletinProblemInfoScreenDestination) {
         BulletinProblemInfoScreen()
     }

--- a/common/feature/bulletin/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/bulletin/presentation/screen/BulletinScreen.kt
+++ b/common/feature/bulletin/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/bulletin/presentation/screen/BulletinScreen.kt
@@ -16,11 +16,14 @@ import ge.avalanche.zvavi.bulletin.presentation.models.BulletinEvent
 import ge.avalanche.zvavi.bulletin.presentation.screen.utill.ErrorContent
 import ge.avalanche.zvavi.designsystem.animation.shimmer.ShimmerState
 import ge.avalanche.zvavi.designsystem.animation.shimmer.ZvaviShimmerProvider
+import ge.avalanche.zvavi.foundation.navigation.BulletinProblemInfoScreenDestination
+import ge.avalanche.zvavi.foundation.navigation.ExploreAvalancheSizeInfoScreenDestination
+import ge.avalanche.zvavi.foundation.navigation.ZvaviNavDestinations
 import org.koin.compose.koinInject
 
 @Composable
 internal fun BulletinScreen(
-    onNavigate: () -> Unit,
+    onNavigate: (ZvaviNavDestinations) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val viewModel: BulletinViewModel = koinInject()
@@ -61,10 +64,13 @@ internal fun BulletinScreen(
     // Handle navigation actions
     when (viewAction) {
         is BulletinAction.OpenProblemInfoScreen -> {
-            onNavigate()
+            onNavigate(BulletinProblemInfoScreenDestination)
             viewModel.clearAction()
         }
-
+        is BulletinAction.OpenAvalancheSizeInfoScreen -> {
+            onNavigate(ExploreAvalancheSizeInfoScreenDestination)
+            viewModel.clearAction()
+        }
         else -> {}
     }
 }

--- a/common/feature/bulletin/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/bulletin/presentation/screen/BulletinView.kt
+++ b/common/feature/bulletin/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/bulletin/presentation/screen/BulletinView.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
@@ -71,7 +72,8 @@ internal fun BulletinView(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(ZvaviTheme.colors.layerFloor0)
+            .padding(horizontal = layoutConfig.marginHorizontal)
+             .background(ZvaviTheme.colors.layerFloor0)
     ) {
         Box(
             modifier = Modifier
@@ -140,6 +142,6 @@ private fun ContentBlocks(
             eventHandler = eventHandler,
             layoutConfig = layoutConfig
         )
-        AvalanchesSnowpackWeatherBlock(layoutConfig, viewState = viewState)
+        AvalanchesSnowpackWeatherBlock(layoutConfig, viewState = viewState,eventHandler = eventHandler)
     }
 }

--- a/common/feature/bulletin/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/bulletin/presentation/screen/copmponents/blocks/AvalanchesSnowpackWeatherBlock.kt
+++ b/common/feature/bulletin/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/bulletin/presentation/screen/copmponents/blocks/AvalanchesSnowpackWeatherBlock.kt
@@ -1,20 +1,22 @@
 package ge.avalanche.zvavi.bulletin.presentation.screen.copmponents.blocks
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkVertically
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -23,109 +25,339 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.Dp
+import ge.avalanche.zvavi.bulletin.api.models.Aspects
+import ge.avalanche.zvavi.bulletin.api.models.RecentAvalanche
+import ge.avalanche.zvavi.bulletin.presentation.models.BulletinEvent
 import ge.avalanche.zvavi.bulletin.presentation.models.BulletinViewState
-import ge.avalanche.zvavi.designsystem.dimens.ZvaviAngle
+import ge.avalanche.zvavi.designsystem.components.expandableSection.ZvaviExpandableSection
+import ge.avalanche.zvavi.designsystem.dimens.ZvaviRadius
+import ge.avalanche.zvavi.designsystem.dimens.ZvaviSize
 import ge.avalanche.zvavi.designsystem.dimens.ZvaviSpacing
+import ge.avalanche.zvavi.designsystem.dimens.ZvaviStroke
 import ge.avalanche.zvavi.designsystem.icons.ZvaviIcons
+import ge.avalanche.zvavi.designsystem.strings.ZvaviStrings
 import ge.avalanche.zvavi.designsystem.theme.ZvaviTheme
 import ge.avalanche.zvavi.designsystem.tokens.layout.LayoutConfig
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun AvalanchesSnowpackWeatherBlock(
     layoutConfig: LayoutConfig,
     viewState: BulletinViewState,
+    eventHandler: (BulletinEvent) -> Unit,
     modifier: Modifier = Modifier
 ) {
     var expandedStateAvalanche by remember { mutableStateOf(false) }
     var expandedStateSnowPack by remember { mutableStateOf(false) }
     var expandedStateWeather by remember { mutableStateOf(false) }
+
     Column(
         verticalArrangement = Arrangement.spacedBy(ZvaviSpacing.spacing100),
-        modifier = modifier.fillMaxWidth().wrapContentHeight()
+        modifier = modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
             .padding(
                 top = ZvaviSpacing.spacing400,
                 start = layoutConfig.contentCompensation,
                 end = layoutConfig.contentCompensation
             )
     ) {
-        ZvaviExpandableText(
-            fieldName = ("Recent avalanches"),
+        // Avalanche Section
+        ZvaviExpandableSection(
+            sectionTitle = {
+                AccentText(
+                    text = stringResource(ZvaviStrings.recentAvalanches),
+                    modifier = Modifier.weight(1f)
+                )
+            },
             isExpanded = expandedStateAvalanche,
-            onExpandedChange = { expandedStateAvalanche = it },
-            information = viewState.recentAvalanches.toString(),
-            modifier = modifier
-        )
-        ZvaviExpandableText(
-            fieldName = "Snowpack",
+            onExpandedChange = { expandedStateAvalanche = it }
+        ) {
+            viewState.recentAvalanches.forEach { recentAvalanche ->
+                AvalancheCell(recentAvalanche, eventHandler)
+            }
+        }
+
+        // Snowpack Section  
+        ZvaviExpandableSection(
+            sectionTitle = {
+                AccentText(
+                    text = stringResource(ZvaviStrings.snowpack),
+                    modifier = Modifier.weight(1f)
+                )
+            },
             isExpanded = expandedStateSnowPack,
-            onExpandedChange = { expandedStateSnowPack = it },
-            information = viewState.snowpack,
-            modifier = modifier
-        )
-        ZvaviExpandableText(
-            fieldName = "Weather",
+            onExpandedChange = { expandedStateSnowPack = it }
+        ) {
+            BodyText(text = viewState.snowpack)
+        }
+
+        // Weather Section
+        ZvaviExpandableSection(
+            sectionTitle = {
+                AccentText(
+                    text = stringResource(ZvaviStrings.weather),
+                    modifier = Modifier.weight(1f)
+                )
+            },
             isExpanded = expandedStateWeather,
-            onExpandedChange = { expandedStateWeather = it },
-            information = viewState.weather,
-            modifier = modifier
+            onExpandedChange = { expandedStateWeather = it }
+        ) {
+            BodyText(text = viewState.weather)
+        }
+    }
+}
+
+@Composable
+fun AvalancheCell(
+    recentAvalanche: RecentAvalanche,
+    eventHandler: (BulletinEvent) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(
+                color = ZvaviTheme.colors.overlayNeutral,
+                shape = RoundedCornerShape(ZvaviRadius.radius550)
+            )
+            .border(
+                width = ZvaviStroke.stroke200,
+                shape = RoundedCornerShape(ZvaviRadius.radius550),
+                color = ZvaviTheme.colors.borderNeutralTertiary
+            )
+            .padding(ZvaviSpacing.spacing350)
+    ) {
+        AvalancheHeader(recentAvalanche = recentAvalanche, eventHandler = eventHandler)
+        VerticalSpacer(spacing = ZvaviSpacing.spacing250)
+        AspectsByElevationSection(aspects = recentAvalanche.aspects)
+        VerticalSpacer(spacing = ZvaviSpacing.spacing250)
+        DetailedDescriptionSection(description = recentAvalanche.description)
+    }
+    VerticalSpacer(spacing = ZvaviSpacing.spacing100)
+}
+
+@Composable
+private fun AvalancheHeader(
+    recentAvalanche: RecentAvalanche,
+    eventHandler: (BulletinEvent) -> Unit,
+) {
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = ZvaviSpacing.spacing200)
+    ) {
+        AvalancheDate(text = recentAvalanche.date)
+
+        Row(horizontalArrangement = Arrangement.End) {
+            AvalancheSize(text = "Size: ${recentAvalanche.size}")
+            Spacer(modifier = Modifier.size(ZvaviSpacing.spacing350))
+            InfoButton(eventHandler = eventHandler)
+        }
+    }
+}
+
+@Composable
+private fun AspectsByElevationSection(aspects: Aspects) { // Replace Any with proper type
+    SectionTitle(text = stringResource(ZvaviStrings.aspectByElevation))
+    VerticalSpacer(spacing = ZvaviSpacing.spacing250)
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(IntrinsicSize.Min)
+            .padding(bottom = ZvaviSpacing.spacing200)
+    ) {
+        val elevationData = listOf(
+            stringResource(ZvaviStrings.highAlpine) to aspects.highAlpine.keys,
+            stringResource(ZvaviStrings.alpine) to aspects.alpine.keys,
+            stringResource(ZvaviStrings.subAlpine) to aspects.subAlpine.keys
+        )
+
+        elevationData.forEachIndexed { index, (elevation, aspectText) ->
+            if (index > 0) {
+                Spacer(modifier = Modifier.weight(0.05f))
+            }
+            if (aspectText.isNotEmpty()) {
+                ElevationCell(
+                    elevationText = elevation,
+                    aspectText = { ColoredElevationText(aspectText) },
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailedDescriptionSection(description: String) {
+    SectionTitle(text = stringResource(ZvaviStrings.detailedDescription))
+    VerticalSpacer(spacing = ZvaviSpacing.spacing250)
+    BodyText(
+        text = description,
+        modifier = Modifier.padding(horizontal = ZvaviSpacing.spacing250)
+    )
+}
+
+@Composable
+private fun InfoButton(eventHandler: (BulletinEvent) -> Unit) {
+    IconButton(
+        onClick = { eventHandler(BulletinEvent.AvalancheSizeInfoClicked) },
+        modifier = Modifier.size(ZvaviSize.size150)
+    ) {
+        Icon(
+            imageVector = ZvaviIcons.InfoIcon,
+            contentDescription = stringResource(ZvaviStrings.info),
+            tint = ZvaviTheme.colors.contentNeutralTertiary,
+            modifier = Modifier.size(ZvaviSize.size100) // Use design system token
         )
     }
 }
 
 @Composable
-fun ZvaviExpandableText(
-    fieldName: String,
-    isExpanded: Boolean,
-    onExpandedChange: (Boolean) -> Unit,
-    information: String,
-    modifier: Modifier = Modifier
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-    val rotationAngle = animateFloatAsState(
-        targetValue = if (isExpanded) ZvaviAngle.angle0 else ZvaviAngle.angleMinus90,
-        label = ""
-    )
+fun ColoredElevationText(aspects: Set<String>) {
+    if (aspects.isEmpty()) {
+        AvalancheAspects(text = "* * *")
+        return
+    }
     Column(
-        verticalArrangement = Arrangement.Center,
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable(interactionSource, null) { onExpandedChange(!isExpanded) }
-            .wrapContentHeight()
-            .padding(vertical = ZvaviSpacing.spacing150)
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.fillMaxWidth()
     ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = fieldName,
-                style = ZvaviTheme.typography.compact300Accent.copy(color = ZvaviTheme.colors.contentNeutralPrimary),
-                modifier = Modifier.weight(1f)
-            )
-
-            Icon(
-                imageVector = ZvaviIcons.DropDownArrow,
-                contentDescription = if (isExpanded) "collapse" else "expanded",
-                tint = ZvaviTheme.colors.contentNeutralTertiary,
-                modifier = Modifier.graphicsLayer(rotationZ = rotationAngle.value)
-            )
-        }
-        AnimatedVisibility(
-            visible = isExpanded,
-            enter = expandVertically() + fadeIn(),
-            exit = shrinkVertically() + fadeOut()
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth().padding(horizontal = 8.dp, vertical = 8.dp)
+        aspects.chunked(3).forEach { rowAspects ->
+            Row(
+                horizontalArrangement = Arrangement.Center,
+                modifier = Modifier.fillMaxWidth()
             ) {
-                Text(
-                    text = information,
-                    style = ZvaviTheme.typography.text300Default,
-                    color = ZvaviTheme.colors.contentNeutralPrimary
-                )
+                rowAspects.forEach { aspect ->
+                    AvalancheAspects(
+                        text = aspect.uppercase(),
+                        modifier = Modifier.padding(horizontal = ZvaviSpacing.spacing150)
+                    )
+                }
             }
         }
     }
+}
+
+@Composable
+fun ElevationCell(
+    elevationText: String,
+    aspectText: @Composable () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier.fillMaxHeight()
+    ) {
+        DefaultText(text = elevationText)
+        VerticalSpacer(spacing = ZvaviSpacing.spacing200)
+        aspectText()
+        HorizontalDivider(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = ZvaviSpacing.spacing250),
+            color = ZvaviTheme.colors.borderNeutralTertiary,
+            thickness = ZvaviStroke.stroke100
+        )
+    }
+}
+
+@Composable
+private fun AccentText(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = text,
+        style = ZvaviTheme.typography.compact300Accent,
+        color = ZvaviTheme.colors.contentNeutralPrimary,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun BodyText(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = text,
+        style = ZvaviTheme.typography.text300Default,
+        color = ZvaviTheme.colors.contentNeutralPrimary,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun AvalancheDate(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = text,
+        style = ZvaviTheme.typography.display350Accent,
+        color = ZvaviTheme.colors.contentNeutralPrimary,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun AvalancheSize(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = text,
+        style = ZvaviTheme.typography.display350Accent,
+        color = ZvaviTheme.colors.backgroundBrandHigh,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun AvalancheAspects(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = text,
+        style = ZvaviTheme.typography.text250Accent,
+        color = ZvaviTheme.colors.backgroundBrandHigh,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun SectionTitle(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = text,
+        style = ZvaviTheme.typography.text200Accent,
+        color = ZvaviTheme.colors.contentNeutralSecondary,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun DefaultText(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = text,
+        style = ZvaviTheme.typography.text250Default,
+        color = ZvaviTheme.colors.contentNeutralPrimary,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun VerticalSpacer(spacing: Dp) {
+    Spacer(modifier = Modifier.size(spacing))
 }

--- a/common/feature/bulletin/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/bulletin/presentation/screen/copmponents/blocks/ProblemsBlock.kt
+++ b/common/feature/bulletin/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/bulletin/presentation/screen/copmponents/blocks/ProblemsBlock.kt
@@ -14,6 +14,7 @@ import ge.avalanche.zvavi.bulletin.presentation.models.BulletinEvent
 import ge.avalanche.zvavi.bulletin.presentation.models.BulletinViewState
 import ge.avalanche.zvavi.bulletin.presentation.screen.copmponents.boards.ZvaviProblemBoard
 import ge.avalanche.zvavi.bulletin.presentation.screen.dialogs.AvalancheProblemsBottomSheet
+import ge.avalanche.zvavi.designsystem.components.header.ZvaviHeader
 import ge.avalanche.zvavi.designsystem.dimens.ZvaviSpacing
 import ge.avalanche.zvavi.designsystem.strings.ZvaviStrings
 import ge.avalanche.zvavi.designsystem.theme.ZvaviTheme
@@ -39,20 +40,14 @@ fun ProblemsBlock(
             .wrapContentHeight()
             .padding(top = ZvaviSpacing.spacing350)
     ) {
-        Text(
-            text = stringResource(ZvaviStrings.problems),
-            style = ZvaviTheme.typography.display400Accent.copy(
-                color = ZvaviTheme.colors.contentNeutralPrimary
-            ),
-            modifier = Modifier
-                .fillMaxWidth()
-                .wrapContentHeight()
-                .padding(
-                    start = layoutConfig.contentCompensation,
-                    end = layoutConfig.contentCompensation,
-                    bottom = ZvaviSpacing.spacing100,
-                    top = ZvaviSpacing.spacing300
-                )
+        ZvaviHeader(
+            text = ZvaviStrings.problems,
+            modifier = modifier.padding(
+                start = layoutConfig.contentCompensation,
+                end = layoutConfig.contentCompensation,
+                bottom = ZvaviSpacing.spacing100,
+                top = ZvaviSpacing.spacing300
+            )
         )
         Column(
             verticalArrangement = Arrangement.spacedBy(ZvaviSpacing.spacing100),
@@ -69,7 +64,6 @@ fun ProblemsBlock(
     }
     if (viewState.showBottomSheet) {
         AvalancheProblemsBottomSheet(
-            viewState=viewState,
             problem = viewState.selectedProblem,
             sheetState = bottomSheetState,
             layoutConfig = layoutConfig,

--- a/common/feature/bulletin/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/bulletin/presentation/screen/copmponents/blocks/RiskByHeightBlock.kt
+++ b/common/feature/bulletin/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/bulletin/presentation/screen/copmponents/blocks/RiskByHeightBlock.kt
@@ -21,6 +21,7 @@ import ge.avalanche.zvavi.bulletin.presentation.screen.copmponents.views.Pentago
 import ge.avalanche.zvavi.bulletin.presentation.screen.copmponents.views.RectangleView
 import ge.avalanche.zvavi.bulletin.presentation.screen.utill.StyledPyramidText
 import ge.avalanche.zvavi.bulletin.presentation.screen.utill.toColor
+import ge.avalanche.zvavi.designsystem.components.header.ZvaviHeader
 
 import ge.avalanche.zvavi.designsystem.dimens.ZvaviSpacing
 import ge.avalanche.zvavi.designsystem.strings.ZvaviStrings
@@ -44,11 +45,9 @@ fun RiskByHeightBlock(
     ) {
         RiskRow(
             topText = {
-                Text(
-                    text = stringResource(ZvaviStrings.riskByHeight),
-                    style = ZvaviTheme.typography.display400Accent.copy(color = ZvaviTheme.colors.contentNeutralPrimary),
-                    color = ZvaviTheme.colors.contentNeutralSecondary,
-                    modifier = Modifier.fillMaxWidth().padding(vertical = ZvaviSpacing.spacing100)
+                ZvaviHeader(
+                    text = (ZvaviStrings.riskByHeight),
+                    modifier = Modifier.padding(vertical = ZvaviSpacing.spacing100)
                 )
             },
             bottomText = stringResource(ZvaviStrings.highAlpine),

--- a/common/feature/bulletin/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/bulletin/presentation/screen/dialogs/AvalancheProblemsBottomSheet.kt
+++ b/common/feature/bulletin/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/bulletin/presentation/screen/dialogs/AvalancheProblemsBottomSheet.kt
@@ -47,7 +47,6 @@ import ge.avalanche.zvavi.designsystem.tokens.layout.LayoutConfig
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun AvalancheProblemsBottomSheet(
-    viewState: BulletinViewState,
     problem: AvalancheProblem?,
     sheetState: SheetState,
     layoutConfig: LayoutConfig,
@@ -69,7 +68,6 @@ internal fun AvalancheProblemsBottomSheet(
     ) {
         problem?.let {
             ModalContainer(
-                viewState = viewState,
                 problem = it,
                 layoutConfig,
                 eventHandler,
@@ -81,7 +79,6 @@ internal fun AvalancheProblemsBottomSheet(
 
 @Composable
 private fun ModalContainer(
-    viewState: BulletinViewState,
     problem: AvalancheProblem,
     layoutConfig: LayoutConfig,
     eventHandler: (BulletinEvent) -> Unit,
@@ -131,7 +128,6 @@ private fun ModalContainer(
                 )
             }
             DashBoard(
-                viewState = viewState,
                 problem = problem,
                 eventHandler = eventHandler,
                 layoutConfig = layoutConfig
@@ -142,7 +138,6 @@ private fun ModalContainer(
 
 @Composable
 private fun DashBoard(
-    viewState: BulletinViewState,
     problem: AvalancheProblem,
     layoutConfig: LayoutConfig,
     eventHandler: (BulletinEvent) -> Unit

--- a/common/feature/explore/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/explore/presentation/navigation/ExploreGraph.kt
+++ b/common/feature/explore/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/explore/presentation/navigation/ExploreGraph.kt
@@ -2,7 +2,9 @@ package ge.avalanche.zvavi.explore.presentation.navigation
 
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptionsBuilder
+import ge.avalanche.zvavi.explore.presentation.screen.ExploreAvalancheSizeInfoScreen
 import ge.avalanche.zvavi.explore.presentation.screen.ExploreScreen
+import ge.avalanche.zvavi.foundation.navigation.ExploreAvalancheSizeInfoScreenDestination
 import ge.avalanche.zvavi.foundation.navigation.ExplorerScreenDestination
 import ge.avalanche.zvavi.foundation.navigation.ZvaviNavDestinations
 import ge.avalanche.zvavi.foundation.navigation.zvaviComposable
@@ -13,5 +15,8 @@ fun NavGraphBuilder.exploreGraph(
 ) {
     zvaviComposable(destinations = ExplorerScreenDestination) {
         ExploreScreen()
+    }
+    zvaviComposable(destinations = ExploreAvalancheSizeInfoScreenDestination){
+        ExploreAvalancheSizeInfoScreen()
     }
 }

--- a/common/feature/explore/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/explore/presentation/screen/ExploreAvalancheSizeInfoScreen.kt
+++ b/common/feature/explore/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/explore/presentation/screen/ExploreAvalancheSizeInfoScreen.kt
@@ -1,0 +1,15 @@
+package ge.avalanche.zvavi.explore.presentation.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun ExploreAvalancheSizeInfoScreen() {
+    Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+        Text(text = "Avalanche Size Info")
+    }
+}

--- a/common/feature/explore/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/explore/presentation/screen/ExploreScreen.kt
+++ b/common/feature/explore/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/explore/presentation/screen/ExploreScreen.kt
@@ -1,15 +1,96 @@
 package ge.avalanche.zvavi.explore.presentation.screen
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import ge.avalanche.zvavi.designsystem.components.expandableSection.ZvaviExpandableSection
+import ge.avalanche.zvavi.designsystem.components.header.ZvaviHeader
+import ge.avalanche.zvavi.designsystem.dimens.ZvaviSpacing
+import ge.avalanche.zvavi.designsystem.strings.ZvaviStrings
+import ge.avalanche.zvavi.designsystem.theme.ZvaviTheme
+import ge.avalanche.zvavi.designsystem.tokens.layout.LayoutConfig
+import ge.avalanche.zvavi.designsystem.tokens.layout.LocalLayoutConfig
+import org.jetbrains.compose.resources.StringResource
+
+private class ExploreExpandableSection(
+    val title: String,
+    val isExpanded: Boolean,
+    val onExpandedChange: (Boolean) -> Unit,
+    val content: @Composable ColumnScope.() -> Unit
+)
 
 @Composable
 fun ExploreScreen() {
+    val layoutConfig = LocalLayoutConfig.current
     Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
-        Text(text = "EXPLORE")
+        ExploreView(layoutConfig = layoutConfig)
     }
+}
+
+@Composable
+fun ExploreView(
+    layoutConfig: LayoutConfig,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(ZvaviSpacing.spacing100),
+        modifier = modifier.fillMaxSize().padding(
+            vertical = ZvaviSpacing.spacing350,
+            horizontal = layoutConfig.marginHorizontal,
+        )
+    ) {
+        AvalancheBlock(layoutConfig = layoutConfig)
+
+    }
+}
+
+@Composable
+fun AvalancheBlock(
+    layoutConfig: LayoutConfig,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(ZvaviSpacing.spacing200),
+        modifier = Modifier.fillMaxWidth().wrapContentHeight().padding(
+            top = ZvaviSpacing.spacing350,
+            start = layoutConfig.contentCompensation,
+            end = layoutConfig.contentCompensation
+        )
+    ) {
+        ZvaviHeader(
+            text = ZvaviStrings.explore,
+            modifier = modifier.padding(
+                top = ZvaviSpacing.spacing300 + ZvaviSpacing.spacing100,
+                bottom = ZvaviSpacing.spacing100
+            )
+        )
+        ZvaviExpandableSection(
+            sectionTitle = { ExploreBodyText(text = ZvaviStrings.avalancheSafety,modifier = Modifier.weight(1f)) },
+            isExpanded = true,
+            onNavigateClick = { /* Handle navigation */ }
+        )
+
+    }
+}
+
+@Composable
+fun ExploreBodyText(
+    text: StringResource,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = "Avalanche problems",
+        style = ZvaviTheme.typography.compact300Default,
+        color = ZvaviTheme.colors.contentNeutralPrimary,
+        modifier = modifier.fillMaxWidth().wrapContentHeight(),
+    )
 }

--- a/common/feature/splash/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/splash/presentation/SplashScreenViewModel.kt
+++ b/common/feature/splash/presentation/src/commonMain/kotlin/ge/avalanche/zvavi/splash/presentation/SplashScreenViewModel.kt
@@ -24,7 +24,6 @@ class SplashScreenViewModel : BaseViewModel<SplashViewState, SplashAction, Splas
     
     private fun initializeSplash() {
         viewModelScope.launch {
-            // Simulate splash screen loading time
             delay(2000) // 2 seconds delay
             navigateToMainScreen()
         }


### PR DESCRIPTION
Renames `RecentAvalanches` to `RecentAvalanche` for clarity and consistency. Updates the data mapping logic to correctly format dates for the bulletin. Introduces a new UI component, `AvalanchesSnowpackWeatherBlock`, to organize bulletin details. Adjusts the dashboard border width to use the `ZvaviStroke` dimension.